### PR TITLE
Fix cmodview download link

### DIFF
--- a/ru/utilites.html
+++ b/ru/utilites.html
@@ -73,7 +73,7 @@
                         	    <br/><br/>
                         	    <ul>
                                 <li><a href="/forum/viewtopic.php?f=25&t=15775" target="_blank">Подробное описание</a></li>
-                                <li><a class="icon fa-download" href="/cc/cmodview-zip"> Скачать</a></li>
+                                <li><a class="icon fa-download" href="/forum/download/file.php?id=11108&filename=cmodview.zip"> Скачать</a></li>
                                 </ul>
                                 </p>
                             	<hr>

--- a/utilites.html
+++ b/utilites.html
@@ -73,7 +73,7 @@
                         	    <br/><br/>
                         	    <ul>
                                 <li><a href="/forum/viewtopic.php?f=25&t=15775" target="_blank">Detailed description</a></li>
-                                <li><a class="icon fa-download" href="/cc/cmodview-zip"> Download</a></li>
+                                <li><a class="icon fa-download" href="/forum/download/file.php?id=11108&filename=cmodview.zip"> Download</a></li>
                                 </ul>
                                 </p>
                             	<hr>


### PR DESCRIPTION
It now links to the zip file that I recently uploaded to the forum; I could change it if there's another working download link somewhere.