### PR TITLE
Add help to Debian/Ubuntu instructions

### DIFF
--- a/deb.html
+++ b/deb.html
@@ -68,6 +68,7 @@ curl -s https://celestia.space/packages/celestia.key | sudo apt-key add -
 echo deb https://celestia.space/packages SUITE COMPONENT | sudo tee /etc/apt/sources.list.d/celestia.list
 </pre>
 Replace <em>SUITE</em> with your distribution codename (stretch, buster, xenial, bionic, focal) and <em>COMPONENT</em> with <em>main</em> if you use Debian or with <em>universe</em> if you use Ubuntu.
+Both of these values can be determined by running the <pre>lsb_release -a</pre> commdand.
 							</section>
 					</div>
 				</div>

--- a/deb.html
+++ b/deb.html
@@ -67,7 +67,8 @@
 curl -s https://celestia.space/packages/celestia.key | sudo apt-key add -
 echo deb https://celestia.space/packages SUITE COMPONENT | sudo tee /etc/apt/sources.list.d/celestia.list
 </pre>
-Replace <em>SUITE</em> with your distribution codename (stretch, buster, xenial, bionic, focal) and <em>COMPONENT</em> with <em>main</em> if you use Debian or with <em>universe</em> if you use Ubuntu.
+Replace <em>SUITE</em> with your distribution codename (stretch, buster, xenial, bionic, focal).
+If SUITE is either xenial or bionic, <em>COMPONENT</em> is <em>universe</em>, otherwise it's <em>main</em>.
 Both of these values can be determined by running the <pre>lsb_release -a</pre> commdand.
 							</section>
 					</div>

--- a/deb.html
+++ b/deb.html
@@ -67,9 +67,8 @@
 curl -s https://celestia.space/packages/celestia.key | sudo apt-key add -
 echo deb https://celestia.space/packages SUITE COMPONENT | sudo tee /etc/apt/sources.list.d/celestia.list
 </pre>
-Replace <em>SUITE</em> with your distribution codename (stretch, buster, xenial, bionic, focal).
-If SUITE is either xenial or bionic, <em>COMPONENT</em> is <em>universe</em>, otherwise it's <em>main</em>.
-Both of these values can be determined by running the <pre>lsb_release -a</pre> commdand.
+<p>Replace <em>SUITE</em> with your distribution codename (stretch, buster, xenial, bionic, focal). If it's either xenial or bionic, replace <em>COMPONENT</em> with <em>universe</em>, otherwise use <em>main</em>.</p>
+<p>To determine your distribution codename, you can run the command: <pre>lsb_release -a</pre></p>
 							</section>
 					</div>
 				</div>

--- a/deb.html
+++ b/deb.html
@@ -64,7 +64,7 @@
 						<!-- Content -->
 							<section id="content">
 <pre>
-curl https://celestia.space/packages/celestia.key | sudo apt-key add -
+curl -s https://celestia.space/packages/celestia.key | sudo apt-key add -
 echo deb https://celestia.space/packages SUITE COMPONENT | sudo tee /etc/apt/sources.list.d/celestia.list
 </pre>
 Replace <em>SUITE</em> with your distribution codename (stretch, buster, xenial, bionic, focal) and <em>COMPONENT</em> with <em>main</em> if you use Debian or with <em>universe</em> if you use Ubuntu.


### PR DESCRIPTION
## Purpose

It's easy to lose track of one's current running version and its code name. This change adds an instruction to help a user determine it.

## Details

* Instruction using `lsb_release` to determine "SUITE"
* Change `curl` command to make `sudo` prompt more prominent
* **Fix:** Correct instruction on which component to use (i.e. in the case of focal, it should be "main" not "universe")

## Preview

![image](https://user-images.githubusercontent.com/5666970/126887020-270fab92-c095-48a7-bdb0-6a9422183a32.png)
