### PR TITLE
A fix for the broken Wikibooks link

### DIFF
--- a/guides.html
+++ b/guides.html
@@ -147,7 +147,7 @@
 										    <li><img src="/flags/ru.png" border="0" height="14" width="14" alt="Russian" align="bottom">&nbsp;<a href="http://celestiamotherlode.net/creators/bhegwood/Dummies_RUS.zip"><b>Документ PDF</b></a> (архив ZIP)</li>
 										</ul>
 										<hr />
-										The <b><a href="https://en.wikibooks.org/wiki/Celestia/">Celestia WikiBook</a></b> contains technical documentation on Celestia for users, add-on creators, and developers. Experienced Celestia users are invited contribute to the Wikibook themselves. 
+										The <b><a href="https://en.wikibooks.org/wiki/Celestia">Celestia WikiBook</a></b> contains technical documentation on Celestia for users, add-on creators, and developers. Experienced Celestia users are invited contribute to the Wikibook themselves. 
 										<hr />
 										Please see the <a href="http://www.celestiamotherlode.net/catalog/documentation.html">documentation page</a> at The Celestia Motherlode for a comprehensive list of documentation available for Celestia. In addition to documentation for Celestia users, there are many files of interest to people who want extend Celestia by creating add-ons and scripts.
 	


### PR DESCRIPTION
as i stated in #25, the link for the wikibooks under the guides tab is broken. its simple to fix, though. and ive done it (hopefully it works lol)