### PR TITLE
update gnu/linux download guides

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -366,10 +366,14 @@
 	}
 
 	.\38 u, .\38 u\24 {
-		width: 66.6666666667%;
+		width: 100%;
 		clear: none;
 		margin-left: 0;
 	}
+
+	    td.\38 u, .\38 u\24 {
+		    width: 66.6666666667%;
+	    }
 
 	.\37 u, .\37 u\24 {
 		width: 58.3333333333%;
@@ -378,7 +382,7 @@
 	}
 
 	.\36 u, .\36 u\24 {
-		width: 50%;
+		width: 100%;
 		clear: none;
 		margin-left: 0;
 	}
@@ -1669,9 +1673,9 @@
 
 	code {
 		background: rgba(255, 255, 255, 0.075);
-		border-radius: 4px;
+		border-radius: 6px;
 		font-family: "Courier New", monospace;
-		font-size: 0.9em;
+		font-size: 17px;
 		margin: 0 0.25em;
 		padding: 0.25em 0.65em;
 	}
@@ -1679,7 +1683,7 @@
 	pre {
 		-webkit-overflow-scrolling: touch;
 		font-family: "Courier New", monospace;
-		font-size: 0.9em;
+		font-size: 0em;
 		margin: 0 0 2em 0;
 	}
 
@@ -2599,15 +2603,14 @@
 
 			ul.actions.fit {
 				display: table;
-				margin-left: -1em;
+				margin-left: 0.75em;
 				padding: 0;
 				table-layout: fixed;
-				width: calc(100% + 1em);
 			}
 
 				ul.actions.fit li {
 					display: table-cell;
-					padding: 0 0 0 1em;
+					padding-left: 0.5em;
 				}
 
 					ul.actions.fit li > * {

--- a/download.html
+++ b/download.html
@@ -66,51 +66,33 @@
 
 						<!-- Content -->
 							<section id="content">
-                                <center>
-                                <i class="fa fa-windows fa-5x"></i>
-                                <h2>Windows</h2>
-                                <p>The Windows package of Celestia is a self-extracting archive. Download it to your computer and then run it.</p>
-                                </center>
-                                <div class="row">
-						        <!--<div class="6u 12u$(xsmall)">
-										<ul class="actions fit">
-											<li><a href="#" class="button special disabled icon fa-download">Celestia 1.7.0b (x64, 0M)</a></li>
-											<li><a href="#" class="button disabled icon fa-download">Celestia 1.7.0b (x86, 0M)</a></li>
-										</ul>
-									</div>-->
-									<div class="8u 12u$(xsmall)">
-										<ul class="actions fit">
-											<li><a href="https://github.com/CelestiaProject/Celestia/releases/download/1.6.2.2/celestia-1.6.2.2-win.exe" class="button special icon fa-download">Celestia 1.6.2.2 (x86/x64, 36M)</a></li>
-											<li><a href="/cc/celestia-win-161" class="button icon fa-download">Celestia 1.6.1 (x86, 33M)</a></li>
-											<!--li><a href="/cc/celestia-win-160" class="button icon fa-download">Celestia 1.6.0 (x86, 34M)</a></li-->
-										</ul>
-									</div>
-								</div>
-                                <center>
-                                <i class="fa fa-linux fa-5x"></i>
-                                <h2>GNU/Linux</h2>
-                                <p>If you are running Debian or Ubuntu, see the instructions at the link below.</p>
-                                </center>
-                                <div class="row">
-									<!--<div class="6u 12u$(xsmall)">
+								<center>
+								<i class="fa fa-windows fa-5x"></i>
+								<h2>Windows</h2>
+								<p>The Windows package of Celestia is a self-extracting archive. Download it to your computer and then run it.</p>
+								</center>
+								<div class="row">
+								<!--<div class="6u 12u$(xsmall)">
 										<ul class="actions fit">
 											<li><a href="#" class="button special disabled icon fa-download">Celestia 1.7.0 (x64, 0M)</a></li>
 											<li><a href="#" class="button disabled icon fa-download">Celestia 1.7.0 (x86, 0M)</a></li>
 										</ul>
 									</div>-->
 									<div class="8u 12u$(xsmall)">
-										<ul class="actions fit">
-											<li><a href="/deb.html" target="_blank" class="button special">Get Celestia (x86/x64)</a></li>
-											<!--<li><a href="/cc/celestia-linux-150" class="button icon fa-download">Celestia 1.5.0 (x86, 23M)</a></li>-->
-										</ul>
+										<center>
+											<ul class="actions fit">
+												<li><a href="https://github.com/CelestiaProject/Celestia/releases/download/1.6.2.2/celestia-1.6.2.2-win.exe" class="button special icon fa-download">Celestia 1.6.2.2 (x86/x64, 36M)</a></li>
+												<li><a href="/cc/celestia-win-161" class="button icon fa-download">Celestia 1.6.1 (x86, 33M)</a></li>
+											</ul>
+										</center>
 									</div>
 								</div>
-                                <center>
-                                <i class="fa fa-apple fa-5x"></i>
-                                <h2>macOS</h2>
-                                <p>The macOS packages for versions 1.6.0 and 1.6.1 are disk image. Download one to your computer, double click it, and follow the instructions in the README. The package for 1.6.2 is a zipped bundle, download it and unpack.</p>
-                                </center>
-                                <div class="row">
+								<center>
+								<i class="fa fa-apple fa-5x"></i>
+								<h2>macOS</h2>
+								<p>The macOS package for version 1.6.1 is a disk image. Download it to your computer, double click it, and follow the instructions in the README. The package for 1.6.2 is a zipped bundle, download it and unpack.</p>
+								</center>
+								<div class="row">
 									<!--<div class="6u 12u$(xsmall)">
 										<ul class="actions fit">
 											<li><a href="#" class="button special disabled icon fa-download">Celestia 1.7.0 (x64, 0M)</a></li>
@@ -118,31 +100,51 @@
 										</ul>
 									</div>-->
 									<div class="6u 12u$(xsmall)">
-										<ul class="actions fit">
-											<li><a href="https://github.com/CelestiaProject/Celestia/releases/download/1.6.2/celestia-1.6.2-macOS.zip" class="button special icon fa-download">Celestia 1.6.2 (41M)</a></li>
-											<li><a href="/cc/celestia-osx-161" class="button icon fa-download">Celestia 1.6.1 (37M)</a></li>
-											<!--li><a href="/cc/celestia-osx-160" class="button icon fa-download">Celestia 1.6.0 (39M)</a></li-->
-										</ul>
+										<center>
+											<ul class="actions fit">
+												<li><a href="https://github.com/CelestiaProject/Celestia/releases/download/1.6.2/celestia-1.6.2-macOS.zip" class="button special icon fa-download">Celestia 1.6.2 (41M)</a></li>
+												<li><a href="/cc/celestia-osx-161" class="button icon fa-download">Celestia 1.6.1 (37M)</a></li>
+											</ul>
+										</center>
 									</div>
 								</div>
-                                <center>
-                                <i class="fa fa-file-code-o fa-5x"></i>
-                                <h2>Source Code</h2>
-                                <p>Celestia is an open-source project. As such, its source code is provided and is freely modifiable and redistributable as per the GNU Public License. Installation instructions are provided in the INSTALL file.</p>
-                                </center>
-                                <div class="row">
-									<div class="6u 12u$(xsmall)">
+								<center>
+								<i class="fa fa-linux fa-5x"></i>
+								<h2>GNU/Linux</h2>
+								<p>See the installation instructions for your distro at the below pages.</p>
+								</center>
+								<div class="row">
+									<!--<div class="6u 12u$(xsmall)">
 										<ul class="actions fit">
-											<li><a href="https://github.com/CelestiaProject/Celestia" target="_blank" class="button special icon fa-github">Current source (GitHub)</a></li>
-											<li><a href="https://github.com/CelestiaProject/Celestia/archive/1.6.2.2.zip" class="button icon fa-download">Celestia 1.6.2.2 (zip, 48M)</a></li>
-											<!--<li><a href="/cc/celestia-src-161" class="button icon fa-download">Celestia 1.6.1 (zip, 51M)</a></li>-->
-											<!--<li><a href="#" class="button disabled icon fa-download">Celestia 1.7.0b (zip, 0M)</a></li>-->
+											<li><a href="#" class="button special disabled icon fa-download">Celestia 1.7.0 (x64, 0M)</a></li>
+											<li><a href="#" class="button disabled icon fa-download">Celestia 1.7.0 (x86, 0M)</a></li>
 										</ul>
+									</div>-->
+									<div class="8u 12u$(xsmall)">
+										<center>
+											<ul class="actions fit">
+												<li><a href="deb.html" target="_blank" class="button special">Debian (x86/x64)</a></li>
+												<li><a href="ubnt.html" target="_blank" class="button special">Ubuntu (x86/x64)</a></li>
+												<li><a href="otherdistros.html" target="_blank" class="button special">Other distros (x86/x64)</a></li>
+											</ul>
+										</center>
 									</div>
+								</div>
+								<center>
+								<i class="fa fa-file-code-o fa-5x"></i>
+								<h2>Source Code</h2>
+								<p>Celestia is an open-source project. As such, its source code is provided and is freely modifiable and redistributable as per the GNU Public License. Installation instructions are provided in the INSTALL file.</p>
+								</center>
+								<div class="row">
 									<div class="6u 12u$(xsmall)">
-										<ul class="actions fit">
-											<li><a href="https://sourceforge.net/p/celestia/code/?source=navbar" target="_blank" class="button icon fa-code-fork">Old source (SourceForge)</a></li>
-										</ul>
+										<center>
+											<ul class="actions fit">
+												<li><a href="https://github.com/CelestiaProject/Celestia" target="_blank" class="button special icon fa-github">Current source (GitHub)</a></li>
+												<li><a href="https://github.com/CelestiaProject/Celestia/archive/1.6.2.2.zip" class="button icon fa-download">Celestia 1.6.2.2 (zip, 48M)</a></li>
+												<li><a href="https://sourceforge.net/p/celestia/code/?source=navbar" target="_blank" class="button icon fa-code-fork">Old source (SourceForge)</a></li>
+												<!--<li><a href="#" class="button disabled icon fa-download">Celestia 1.7.0 (zip, 0M)</a></li>-->
+											</ul>
+										</center>
 									</div>
 								</div>
 							</section>

--- a/otherdistros.html
+++ b/otherdistros.html
@@ -1,7 +1,7 @@
 <!DOCTYPE HTML>
 <html>
 	<head>
-		<title>Celestia: Debian-based</title>
+		<title>Celestia: Other distros</title>
 		<meta charset="utf-8" />
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		<!--[if lte IE 8]><script src="assets/js/ie/html5shiv.js"></script><![endif]-->
@@ -58,26 +58,37 @@
 				<div id="main" class="wrapper style1">
 					<div class="container">
 						<header class="major">
-							<h2>Celestia installation on Debian-based distributions</h2>
+							<h2>Celestia installation on other distributions</h2>
 						</header>
 
 						<!-- Content -->
 							<section id="content">
 								<header class="minor">
-									<h3>On Debian 10 (buster) and derived systems:</h3>
-								</header>
+									<h3>On openSUSE Leap/Tumbleweed:</h3>
+								</header>							
 								<pre>
 								<code>
-curl -fsSL -o celestia.gpg https://download.opensuse.org/repositories/home:/munix9:/unstable/Debian_10/Release.key
-gpg --keyid-format long celestia.gpg
-gpg: WARNING: no command supplied.  Trying to guess what you mean ...
-pub   rsa2048/BDF3F6ACD4D81407 2014-06-09 [SC] [expires: 2023-02-14]
-      3FE0C0AC1FD6F1034B818A14BDF3F6ACD4D81407
-uid                           home:munix9 OBS Project <home:munix9@build.opensuse.org>
-sudo mv celestia.gpg /usr/share/keyrings/celestia.asc
-
-echo "deb [signed-by=/usr/share/keyrings/celestia.asc] https://download.opensuse.org/repositories/home:/munix9:/unstable/Debian_10/ ./" | sudo tee /etc/apt/sources.list.d/celestia-obs.list  
-sudo apt update && sudo apt install celestia
+sudo zypper addrepo https://download.opensuse.org/repositories/home:munix9:unstable/${VERSION}/home:munix9:unstable.repo
+sudo zypper refresh
+sudo zypper install celestia
+								</code>
+								</pre>
+								<p>Where <b>VERSION</b> is '15.3', '15.4', '15.5' or 'openSUSE_Tumbleweed'.</p>
+								<p>See also the download package sites on OBS for <a href="https://software.opensuse.org/download.html?project=home:munix9:unstable&package=celestia">celestia</a> and <a href="https://software.opensuse.org/download.html?project=home:munix9:unstable&package=celestia-data">celestia-data</a>.</p>
+								<header class="minor">
+									<h3>On other GNU/Linux distributions:</h3>
+								</header>
+								<p>If you are running a distribution other than the ones we have mentioned, try the experimental portable AppImage (Also see <a href="https://github.com/CelestiaProject/Celestia/issues/333">Issue #333</a> on our GitHub):</p>
+								<pre>
+								<code>
+wget -O celestia-1.7.0-git-x86_64.AppImage https://download.opensuse.org/repositories/home:/munix9:/unstable/AppImage/celestia-latest-x86_64.AppImage
+chmod 755 celestia-1.7.0-git-x86_64.AppImage
+								</code>
+								</pre>
+								<p>Optionally create a portable, main version-independent $HOME directory in the same folder as the AppImage file:</p>
+								<pre>
+								<code>
+mkdir celestia-1.7.home
 								</code>
 								</pre>
 							</section>

--- a/ubnt.html
+++ b/ubnt.html
@@ -1,7 +1,7 @@
 <!DOCTYPE HTML>
 <html>
 	<head>
-		<title>Celestia: Debian-based</title>
+		<title>Celestia: Ubuntu-based</title>
 		<meta charset="utf-8" />
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		<!--[if lte IE 8]><script src="assets/js/ie/html5shiv.js"></script><![endif]-->
@@ -58,29 +58,23 @@
 				<div id="main" class="wrapper style1">
 					<div class="container">
 						<header class="major">
-							<h2>Celestia installation on Debian-based distributions</h2>
+							<h2>Celestia installation on Ubuntu-based distributions</h2>
 						</header>
 
 						<!-- Content -->
-							<section id="content">
-								<header class="minor">
-									<h3>On Debian 10 (buster) and derived systems:</h3>
-								</header>
-								<pre>
-								<code>
-curl -fsSL -o celestia.gpg https://download.opensuse.org/repositories/home:/munix9:/unstable/Debian_10/Release.key
-gpg --keyid-format long celestia.gpg
-gpg: WARNING: no command supplied.  Trying to guess what you mean ...
-pub   rsa2048/BDF3F6ACD4D81407 2014-06-09 [SC] [expires: 2023-02-14]
-      3FE0C0AC1FD6F1034B818A14BDF3F6ACD4D81407
-uid                           home:munix9 OBS Project <home:munix9@build.opensuse.org>
-sudo mv celestia.gpg /usr/share/keyrings/celestia.asc
-
-echo "deb [signed-by=/usr/share/keyrings/celestia.asc] https://download.opensuse.org/repositories/home:/munix9:/unstable/Debian_10/ ./" | sudo tee /etc/apt/sources.list.d/celestia-obs.list  
+						<section id="content">
+							<header class="minor">
+								<h3>On Ubuntu 20.04/22.04 and derived systems:</h3>
+							</header>
+							<pre>
+							<code>
+curl https://download.opensuse.org/repositories/home:/munix9:/unstable/Ubuntu_${VERSION}/Release.key | sudo apt-key add -
+echo "deb https://download.opensuse.org/repositories/home:/munix9:/unstable/Ubuntu_${VERSION}/ ./" | sudo tee /etc/apt/sources.list.d/celestia-obs.list  
 sudo apt update && sudo apt install celestia
-								</code>
-								</pre>
-							</section>
+							</code>
+							</pre>
+							<p>Where <b>VERSION</b> is 20.04 or 22.04.</p>
+						</section>
 					</div>
 				</div>
 


### PR DESCRIPTION
supersedes #35
screenshots:
![image](https://user-images.githubusercontent.com/67564416/195981326-6a1f8546-6701-43e2-9892-4c6d9a430cb0.png)
_updated guides for different distros_
![image](https://user-images.githubusercontent.com/67564416/195981367-07a4aa6f-95f2-40f9-bea2-cabca1989572.png)
_updated download page_