### PR TITLE
Release of Celestia 1.6.3

### DIFF
--- a/download.html
+++ b/download.html
@@ -20,7 +20,6 @@
 					<nav id="nav">
 						<ul>
 							<li><a href="/">Home</a></li>
-							<li><a href="/">Home</a></li>
 							<li><a href="download.html">Download</a></li>
 							<li><a href="news.html">News</a></li>
 							<li>
@@ -74,16 +73,7 @@
 								</center>
 								<div class="row">
 								<!--<div class="6u 12u$(xsmall)">
-								<center>
-								<i class="fa fa-windows fa-5x"></i>
-								<h2>Windows</h2>
-								<p>The Windows package of Celestia is a self-extracting archive. Download it to your computer and then run it.</p>
-								</center>
-								<div class="row">
-								<!--<div class="6u 12u$(xsmall)">
 										<ul class="actions fit">
-											<li><a href="#" class="button special disabled icon fa-download">Celestia 1.7.0 (x64, 0M)</a></li>
-											<li><a href="#" class="button disabled icon fa-download">Celestia 1.7.0 (x86, 0M)</a></li>
 											<li><a href="#" class="button special disabled icon fa-download">Celestia 1.7.0 (x64, 0M)</a></li>
 											<li><a href="#" class="button disabled icon fa-download">Celestia 1.7.0 (x86, 0M)</a></li>
 										</ul>

--- a/download.html
+++ b/download.html
@@ -20,6 +20,7 @@
 					<nav id="nav">
 						<ul>
 							<li><a href="/">Home</a></li>
+							<li><a href="/">Home</a></li>
 							<li><a href="download.html">Download</a></li>
 							<li><a href="news.html">News</a></li>
 							<li>
@@ -73,7 +74,16 @@
 								</center>
 								<div class="row">
 								<!--<div class="6u 12u$(xsmall)">
+								<center>
+								<i class="fa fa-windows fa-5x"></i>
+								<h2>Windows</h2>
+								<p>The Windows package of Celestia is a self-extracting archive. Download it to your computer and then run it.</p>
+								</center>
+								<div class="row">
+								<!--<div class="6u 12u$(xsmall)">
 										<ul class="actions fit">
+											<li><a href="#" class="button special disabled icon fa-download">Celestia 1.7.0 (x64, 0M)</a></li>
+											<li><a href="#" class="button disabled icon fa-download">Celestia 1.7.0 (x86, 0M)</a></li>
 											<li><a href="#" class="button special disabled icon fa-download">Celestia 1.7.0 (x64, 0M)</a></li>
 											<li><a href="#" class="button disabled icon fa-download">Celestia 1.7.0 (x86, 0M)</a></li>
 										</ul>
@@ -81,8 +91,8 @@
 									<div class="8u 12u$(xsmall)">
 										<center>
 											<ul class="actions fit">
-												<li><a href="https://github.com/CelestiaProject/Celestia/releases/download/1.6.2.2/celestia-1.6.2.2-win.exe" class="button special icon fa-download">Celestia 1.6.2.2 (x86/x64, 36M)</a></li>
-												<li><a href="/cc/celestia-win-161" class="button icon fa-download">Celestia 1.6.1 (x86, 33M)</a></li>
+												<li><a href="https://github.com/CelestiaProject/Celestia/releases/download/1.6.3/celestia-1.6.3.exe" class="button special icon fa-download">Celestia 1.6.3 (x86/x64, 36M)</a></li>
+												<li><a href="https://github.com/CelestiaProject/Celestia/releases/download/1.6.2.2/celestia-1.6.2.2-win.exe" class="button icon fa-download">Celestia 1.6.2.2 (x86/x64, 36M)</a></li>
 											</ul>
 										</center>
 									</div>
@@ -90,7 +100,7 @@
 								<center>
 								<i class="fa fa-apple fa-5x"></i>
 								<h2>macOS</h2>
-								<p>The macOS package for version 1.6.1 is a disk image. Download it to your computer, double click it, and follow the instructions in the README. The package for 1.6.2 is a zipped bundle, download it and unpack.</p>
+								<p>The macOS packages for 1.6.2 and 1.6.3 are both zipped bundles, choose your version, then download it and unpack.</p>
 								</center>
 								<div class="row">
 									<!--<div class="6u 12u$(xsmall)">
@@ -102,8 +112,8 @@
 									<div class="6u 12u$(xsmall)">
 										<center>
 											<ul class="actions fit">
-												<li><a href="https://github.com/CelestiaProject/Celestia/releases/download/1.6.2/celestia-1.6.2-macOS.zip" class="button special icon fa-download">Celestia 1.6.2 (41M)</a></li>
-												<li><a href="/cc/celestia-osx-161" class="button icon fa-download">Celestia 1.6.1 (37M)</a></li>
+												<li><a href="https://github.com/CelestiaProject/Celestia/releases/download/1.6.3/celestia-1.6.3-macOS.zip" class="button special icon fa-download">Celestia 1.6.3 (41M)</a></li>
+												<li><a href="https://github.com/CelestiaProject/Celestia/releases/download/1.6.2/celestia-1.6.2-macOS.zip" class="button icon fa-download">Celestia 1.6.2 (41M)</a></li>
 											</ul>
 										</center>
 									</div>
@@ -140,7 +150,7 @@
 										<center>
 											<ul class="actions fit">
 												<li><a href="https://github.com/CelestiaProject/Celestia" target="_blank" class="button special icon fa-github">Current source (GitHub)</a></li>
-												<li><a href="https://github.com/CelestiaProject/Celestia/archive/1.6.2.2.zip" class="button icon fa-download">Celestia 1.6.2.2 (zip, 48M)</a></li>
+												<li><a href="https://github.com/CelestiaProject/Celestia/archive/refs/tags/1.6.3.zip" class="button icon fa-download">Celestia 1.6.3 (zip, 48M)</a></li>
 												<li><a href="https://sourceforge.net/p/celestia/code/?source=navbar" target="_blank" class="button icon fa-code-fork">Old source (SourceForge)</a></li>
 												<!--<li><a href="#" class="button disabled icon fa-download">Celestia 1.7.0 (zip, 0M)</a></li>-->
 											</ul>

--- a/news.html
+++ b/news.html
@@ -17,10 +17,8 @@
 			<!-- Header -->
 				<header id="header">
 					<h1 id="logo"><a href="/">Celestia</a></h1>
-					<h1 id="logo"><a href="/">Celestia</a></h1>
 					<nav id="nav">
 						<ul>
-							<li><a href="/">Home</a></li>
 							<li><a href="/">Home</a></li>
 							<li><a href="download.html">Download</a></li>
 							<li><a href="news.html">News</a></li>

--- a/news.html
+++ b/news.html
@@ -17,8 +17,10 @@
 			<!-- Header -->
 				<header id="header">
 					<h1 id="logo"><a href="/">Celestia</a></h1>
+					<h1 id="logo"><a href="/">Celestia</a></h1>
 					<nav id="nav">
 						<ul>
+							<li><a href="/">Home</a></li>
 							<li><a href="/">Home</a></li>
 							<li><a href="download.html">Download</a></li>
 							<li><a href="news.html">News</a></li>
@@ -63,6 +65,13 @@
 							<p>News about Celestia</p>
 						</header>
 <table>
+  <tr>
+    <td class="icon fa-calendar"> April 20, 2023</td>
+    <td class="8u$ 12u$(medium) important(medium)">
+      <h3>Celestia 1.6.3</h3>
+      <p>Version 1.6.3 of Celestia is now available for all supported systems. It fixes issues with 3DS models and location handling, macOS-specific problems such as re-adding support for OS X 10.7 to 10.9 and flickering edges on some GPUs, and fixes some issues with the executable name in celestia.desktop and a buffer overflow in the eclipser finder on Unix-based systems. The Bulgarian translation has been updated, and features from 1.7.0 have been backported, including location updates and allowing binary orbits to work without text sources. Celestia 1.6.3 is available for download from the <a href="download.html">download page</a>.</p>
+    </td>
+  </tr>
   <tr>
     <td class="icon fa-calendar"> Dec 09, 2022</td>
     <td class="8u$ 12u$(medium) important(medium)">


### PR DESCRIPTION
with the recent release of 1.6.3, i thought it would be in our best interest to add information about this to the website, even if it is in poor state right now, including adding download links to the download page. as this was all written rather quickly, it may have a few inaccuracies and problems, but i would be ok with making some adjustments if need be

updates made to the news page:
![image](https://user-images.githubusercontent.com/67564416/233372239-9bc5016a-01ed-45d1-9a35-9fb8aaa10254.png)

updates made to the download page:
![image](https://user-images.githubusercontent.com/67564416/233372305-39161686-f2d1-4033-94ec-0c227c7a9c5d.png)
![image](https://user-images.githubusercontent.com/67564416/233372351-2484e110-5200-44f0-a239-16df6997897a.png)

again, feel free to point out issues and i will be glad to fix them