### PR TITLE
remove SourceForge link on download page

### DIFF
--- a/download.html
+++ b/download.html
@@ -141,7 +141,6 @@
 											<ul class="actions fit">
 												<li><a href="https://github.com/CelestiaProject/Celestia" target="_blank" class="button special icon fa-github">Current source (GitHub)</a></li>
 												<li><a href="https://github.com/CelestiaProject/Celestia/archive/refs/tags/1.6.3.zip" class="button icon fa-download">Celestia 1.6.3 (zip, 48M)</a></li>
-												<li><a href="https://sourceforge.net/p/celestia/code/?source=navbar" target="_blank" class="button icon fa-code-fork">Old source (SourceForge)</a></li>
 												<!--<li><a href="#" class="button disabled icon fa-download">Celestia 1.7.0 (zip, 0M)</a></li>-->
 											</ul>
 										</center>


### PR DESCRIPTION
I don't think anybody needs the source code for pre-1.6.x versions, and downloads for those older versions are available here on GitHub anyway. so let's remove it
![Screenshot (1376)](https://github.com/CelestiaProject/www/assets/67564416/11fc0e6c-3a44-456e-933f-b03887ee6111)