### PR TITLE
download link for 1.7.0

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -371,9 +371,9 @@
 		margin-left: 0;
 	}
 
-	    td.\38 u, .\38 u\24 {
-		    width: 66.6666666667%;
-	    }
+		td.\38 u, .\38 u\24 {
+			width: 66.6666666667%;
+		}
 
 	.\37 u, .\37 u\24 {
 		width: 58.3333333333%;
@@ -2713,7 +2713,7 @@
 		-ms-transition: background-color 0.2s ease-in-out, color 0.2s ease-in-out, box-shadow 0.2s ease-in-out;
 		transition: background-color 0.2s ease-in-out, color 0.2s ease-in-out, box-shadow 0.2s ease-in-out;
 		background-color: transparent;
-		border-radius: 4px;
+		border-radius: 8px;
 		border: 0;
 		box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.3);
 		color: #ffffff !important;
@@ -2735,7 +2735,7 @@
 		input[type="button"]:active,
 		.button:hover,
 		.button:active {
-			box-shadow: inset 0 0 0 1px #55b8c4;
+			box-shadow: inset 0 0 0 3px #55b8c4;
 			color: #55b8c4 !important;
 		}
 
@@ -2744,6 +2744,7 @@
 		input[type="button"]:active,
 		.button:active {
 			background-color: rgba(85, 184, 196, 0.15);
+			box-shadow: inset 0 0 0 5px #55b8c4;
 		}
 
 		input[type="submit"].icon:before,
@@ -2790,6 +2791,7 @@
 			input[type="button"].special:hover,
 			.button.special:hover {
 				background-color: #68c0cb;
+				box-shadow: 0 0 10px 1px #68c0cb;
 			}
 
 			input[type="submit"].special:active,
@@ -2797,6 +2799,7 @@
 			input[type="button"].special:active,
 			.button.special:active {
 				background-color: #42b0bd;
+				box-shadow: 0 0 5px 1px #42b0bd;
 			}
 
 		input[type="submit"].disabled, input[type="submit"]:disabled,
@@ -3318,17 +3321,6 @@
 					#header nav ul li > ul {
 						display: none;
 					}
-
-		#eol-warning {
-			background: linear-gradient(#00000000, #ff0000 20%, #ff0000 80%, #00000000);
-			height: 3.5em;
-			left: 0;
-			line-height: 3.5em;
-			position: relative;
-			top: 3.5em;
-			width: 100%;
-			z-index: 100;
-		}
 
 	body.landing #page-wrapper {
 		padding-top: 0;

--- a/download.html
+++ b/download.html
@@ -57,8 +57,8 @@
 					<div class="container">
 						<header class="major">
 							<h2>Download</h2>
-							<p>Please select the appropriate Celestia package for your computer from the list below.</p>
-							<p>Mobile Celestia versions are available at <a href="https://celestia.mobi/" target="_blank">celestia.mobi</a></p>
+							<p>Select the appropriate Celestia package for your computer from the list below</p>
+							<p>Mobile Celestia versions, for both Android and iOS, are available to download at <a href="https://celestia.mobi/" target="_blank">celestia.mobi</a></p>
 						</header>
 
 						<!-- Content -->
@@ -66,18 +66,13 @@
 								<center>
 								<i class="fa fa-windows fa-5x"></i>
 								<h2>Windows</h2>
-								<p>The Windows package of Celestia is a self-extracting archive. Download it to your computer and then run it.</p>
+								<p>The Windows package of Celestia is a self-extracting archive, download it to your computer and then run it. Version 1.7.0 is currently under development, however you can obtain an early build of it from the link below. Since 1.7.0 is constantly being updated, we recommend that you re-download every month to keep up-to-date. If you have any questions about 1.7.0, as it is noticeably different from previous versions, <a href="https://discord.com/invite/WEWDcJh">join our Discord server</a>.</p>
 								</center>
 								<div class="row">
-								<!--<div class="6u 12u$(xsmall)">
-										<ul class="actions fit">
-											<li><a href="#" class="button special disabled icon fa-download">Celestia 1.7.0 (x64, 0M)</a></li>
-											<li><a href="#" class="button disabled icon fa-download">Celestia 1.7.0 (x86, 0M)</a></li>
-										</ul>
-									</div>-->
 									<div class="8u 12u$(xsmall)">
 										<center>
 											<ul class="actions fit">
+												<li><a href="https://drive.google.com/drive/folders/1KJKphu85i-4wQfHqr2tcI88eZ8vZ6Z9U?usp=sharing" class="button special icon fa-download">Celestia 1.7.0 (x86/x64, 486M)</a></li>
 												<li><a href="https://github.com/CelestiaProject/Celestia/releases/download/1.6.4/celestia-1.6.4.exe" class="button special icon fa-download">Celestia 1.6.4 (x86/x64, 36M)</a></li>
 												<li><a href="https://github.com/CelestiaProject/Celestia/releases/download/1.6.3/celestia-1.6.3.exe" class="button icon fa-download">Celestia 1.6.3 (x86/x64, 36M)</a></li>
 											</ul>
@@ -87,18 +82,13 @@
 								<center>
 								<i class="fa fa-apple fa-5x"></i>
 								<h2>macOS</h2>
-								<p>The macOS packages are zipped bundles, choose your version, then download it and unpack.</p>
+								<p>The macOS packages are zipped bundles, choose your version, then download it and unpack. Version 1.7.0 is a simple download from the App Store, however keep in mind that it will have bugs and other issues, as it is still under development and not ready for a full release.</p>
 								</center>
 								<div class="row">
-									<!--<div class="6u 12u$(xsmall)">
-										<ul class="actions fit">
-											<li><a href="#" class="button special disabled icon fa-download">Celestia 1.7.0 (x64, 0M)</a></li>
-											<li><a href="#" class="button disabled icon fa-download">Celestia 1.7.0 (x86, 0M)</a></li>
-										</ul>
-									</div>-->
 									<div class="6u 12u$(xsmall)">
 										<center>
 											<ul class="actions fit">
+												<li><a href="https://apps.apple.com/us/app/celestia-space-simulator/id1500434829" class="button special icon fa-download">Celestia 1.7.0 (365M)</a></li>
 												<li><a href="https://github.com/CelestiaProject/Celestia/releases/download/1.6.4/celestia-1.6.4-macOS.zip" class="button special icon fa-download">Celestia 1.6.4 (41M)</a></li>
 												<li><a href="https://github.com/CelestiaProject/Celestia/releases/download/1.6.3/celestia-1.6.3-macOS.zip" class="button icon fa-download">Celestia 1.6.3 (41M)</a></li>
 											</ul>
@@ -111,12 +101,6 @@
 								<p>See the installation instructions for your distro at the below pages.</p>
 								</center>
 								<div class="row">
-									<!--<div class="6u 12u$(xsmall)">
-										<ul class="actions fit">
-											<li><a href="#" class="button special disabled icon fa-download">Celestia 1.7.0 (x64, 0M)</a></li>
-											<li><a href="#" class="button disabled icon fa-download">Celestia 1.7.0 (x86, 0M)</a></li>
-										</ul>
-									</div>-->
 									<div class="8u 12u$(xsmall)">
 										<center>
 											<ul class="actions fit">


### PR DESCRIPTION
I've had this on my mind for a while, now I'm finally doing it
I uploaded fully-functioning x86 and x64 installations to Google Drive, so that users don't have to go through the hassle of creating a GitHub account, downloading 1.7.0, and manually putting all the pieces together to get a working installation. they also don't need to compile. I then added a new button next to the 1.6.4 download button, and linked that Drive folder to it. to make sure macOS users don't miss out, I also added a new button there and linked the App Store version of Celestia
for fun, I added an effect to the buttons when you hover over them and click them. it's nothing obnoxious, just a `box-shadow` effect (`inset` for regular buttons, not `inset` for "special" buttons)
I'll also update the Google Drive folder every time a new `master` build comes out, so it doesn't stay out-of-date forever

https://github.com/CelestiaProject/www/assets/67564416/07752fcd-af95-4677-b392-dcca57893a52