### PR TITLE
Update bsd.html

### DIFF
--- a/bsd.html
+++ b/bsd.html
@@ -68,7 +68,7 @@
 # Celestia's package can be installed one of multiple ways on FreeBSD systems via pkg(8)
 $ pkg install celestia
 # or
-$ pkg install/astro celestia
+$ pkg install astro/celestia
 # or
 $ pkg install celestia-glut
 


### PR DESCRIPTION
Fixed install instruction error due to misplaced `/`.