### PR TITLE
Download page changes

### DIFF
--- a/download.html
+++ b/download.html
@@ -69,12 +69,6 @@
 								<p>The Windows package of Celestia is a self-extracting archive. Download it to your computer and then run it.</p>
 								</center>
 								<div class="row">
-								<!--<div class="6u 12u$(xsmall)">
-										<ul class="actions fit">
-											<li><a href="#" class="button special disabled icon fa-download">Celestia 1.7.0 (x64, 0M)</a></li>
-											<li><a href="#" class="button disabled icon fa-download">Celestia 1.7.0 (x86, 0M)</a></li>
-										</ul>
-									</div>-->
 									<div class="8u 12u$(xsmall)">
 										<center>
 											<ul class="actions fit">
@@ -82,21 +76,17 @@
 												<li><a href="https://github.com/CelestiaProject/Celestia/releases/download/1.6.4/celestia-1.6.4.exe" class="button special icon fa-download">Celestia 1.6.4 (x86/x64, 36M)</a></li>
 												<li><a href="https://github.com/CelestiaProject/Celestia/releases/download/1.6.3/celestia-1.6.3.exe" class="button icon fa-download">Celestia 1.6.3 (x86/x64, 36M)</a></li>
 											</ul>
+                                            <p>Celestia is now available to wishlist on Steam!</p>
+                                            <iframe src="https://store.steampowered.com/widget/4753420/" frameborder="0" width="646" height="190"></iframe>
 										</center>
 									</div>
-								</div>
+								</div><br />
 								<center>
 								<i class="fa fa-apple fa-5x"></i>
 								<h2>macOS</h2>
-								<p>The macOS packages are zipped bundles, choose your version, then download it and unpack.</p>
+								<p>Celestia 1.7.0 for macOS can be downloaded from the macOS App Store. The macOS packages for older versions, available below, are zipped bundles. Choose your version, then download it and unpack.</p>
 								</center>
 								<div class="row">
-									<!--<div class="6u 12u$(xsmall)">
-										<ul class="actions fit">
-											<li><a href="#" class="button special disabled icon fa-download">Celestia 1.7.0 (x64, 0M)</a></li>
-											<li><a href="#" class="button disabled icon fa-download">Celestia 1.7.0 (x86, 0M)</a></li>
-										</ul>
-									</div>-->
 									<div class="6u 12u$(xsmall)">
 										<center>
 											<ul class="actions fit">
@@ -112,12 +102,6 @@
 								<p>See the installation instructions for your distro at the below pages.</p>
 								</center>
 								<div class="row">
-									<!--<div class="6u 12u$(xsmall)">
-										<ul class="actions fit">
-											<li><a href="#" class="button special disabled icon fa-download">Celestia 1.7.0 (x64, 0M)</a></li>
-											<li><a href="#" class="button disabled icon fa-download">Celestia 1.7.0 (x86, 0M)</a></li>
-										</ul>
-									</div>-->
 									<div class="8u 12u$(xsmall)">
 										<center>
 											<ul class="actions fit">
@@ -134,18 +118,12 @@
 								</div>
 								<center>
 								<i class="fa-brands fa-freebsd fa-5x"></i>
-<!-- for now, use the svg until we switch to the latest fontawesome -->
-<svg style="width:5em;height:5em;" viewBox="0 0 448 512"><path opacity="0.75" fill="rgb(255, 255, 255)" d="M303.7 96.2c11.1-11.1 115.5-77 139.2-53.2 23.7 23.7-42.1 128.1-53.2 139.2-11.1 11.1-39.4.9-63.1-22.9-23.8-23.7-34.1-52-22.9-63.1zM109.9 68.1C73.6 47.5 22 24.6 5.6 41.1c-16.6 16.6 7.1 69.4 27.9 105.7 18.5-32.2 44.8-59.3 76.4-78.7zM406.7 174c3.3 11.3 2.7 20.7-2.7 26.1-20.3 20.3-87.5-27-109.3-70.1-18-32.3-11.1-53.4 14.9-48.7 5.7-3.6 12.3-7.6 19.6-11.6-29.8-15.5-63.6-24.3-99.5-24.3-119.1 0-215.6 96.5-215.6 215.6 0 119 96.5 215.6 215.6 215.6S445.3 380.1 445.3 261c0-38.4-10.1-74.5-27.7-105.8-3.9 7-7.6 13.3-10.9 18.8z"/></svg>
+                                <!-- for now, use the svg until we switch to the latest fontawesome -->
+                                <svg style="width:5em;height:5em;" viewBox="0 0 448 512"><path opacity="0.75" fill="rgb(255, 255, 255)" d="M303.7 96.2c11.1-11.1 115.5-77 139.2-53.2 23.7 23.7-42.1 128.1-53.2 139.2-11.1 11.1-39.4.9-63.1-22.9-23.8-23.7-34.1-52-22.9-63.1zM109.9 68.1C73.6 47.5 22 24.6 5.6 41.1c-16.6 16.6 7.1 69.4 27.9 105.7 18.5-32.2 44.8-59.3 76.4-78.7zM406.7 174c3.3 11.3 2.7 20.7-2.7 26.1-20.3 20.3-87.5-27-109.3-70.1-18-32.3-11.1-53.4 14.9-48.7 5.7-3.6 12.3-7.6 19.6-11.6-29.8-15.5-63.6-24.3-99.5-24.3-119.1 0-215.6 96.5-215.6 215.6 0 119 96.5 215.6 215.6 215.6S445.3 380.1 445.3 261c0-38.4-10.1-74.5-27.7-105.8-3.9 7-7.6 13.3-10.9 18.8z"/></svg>
 								<h2>FreeBSD</h2>
-								<p>The Freebsd package of Celestia is available through FreeBSD's repositories via pkg or as a port. See the installation instructions on the below page.</p>
+								<p>The FreeBSD package of Celestia is available through FreeBSD's repositories via pkg or as a port. See the installation instructions on the below page.</p>
 								</center>
 								<div class="row">
-									<!--<div class="6u 12u$(xsmall)">
-										<ul class="actions fit">
-											<li><a href="#" class="button special disabled icon fa-download">Celestia 1.7.0 (x64, 0M)</a></li>
-											<li><a href="#" class="button disabled icon fa-download">Celestia 1.7.0 (x86, 0M)</a></li>
-										</ul>
-									</div>-->
 									<div class="8u 12u$(xsmall)">
 										<center>
 											<ul class="actions fit">
@@ -180,7 +158,7 @@
 			<!-- Footer -->
 				<footer id="footer">
 					<ul class="icons">
-						<li><a href="https://twitter.com/CelestiaProject" target="_blank" class="icon alt fa-twitter"><span class="label">Twitter</span></a></li>
+						<li><a href="https://x.com/CelestiaProject" target="_blank" class="icon alt fa-twitter"><span class="label">Twitter</span></a></li>
 						<li><a href="https://github.com/CelestiaProject/Celestia" target="_blank" class="icon alt fa-github"><span class="label">GitHub</span></a></li>
 						<li><a href="mailto:team@celestiaproject.space" class="icon alt fa-envelope"><span class="label">Email</span></a></li>
 					</ul>

--- a/win_170.html
+++ b/win_170.html
@@ -66,13 +66,9 @@
 								
 								<ul>
                                 	<li><b><a href="https://github.com/celestiamobile/celestia-170/releases/download/latest/CelestiaInstaller-x64.exe" target="_blank">Celestia 1.7.0 for x64 based Windows Systems (345 MB)</a> <i class="fa fa-download"></i></b><br />
-                                	This version will run on any computer with an amd64 type CPU.<br /></li>
+                                	This version will run on any computer with an x86-64 type CPU.<br /></li>
                                 	<li><b><a href="https://github.com/celestiamobile/celestia-170/releases/download/latest/CelestiaInstaller-x86.exe" target="_blank">Celestia 1.7.0 for x86 based Windows Systems (332 MB)</a> <i class="fa fa-download"></i></b><br />
-                                	This version will run on any computer with either an i686 or amd64 type CPU.</li>
-                                	<li><b><a href="https://github.com/celestiamobile/celestia-170/archive/refs/tags/latest.zip" target="_blank">Source Code for 1.7.0 (ZIP)</a> <i class="fa fa-download"></i></b><br />
-                                    Source code for Celestia 1.7.0 in a ZIP archive.</li>
-                                	<li><b><a href="https://github.com/celestiamobile/celestia-170/archive/refs/tags/latest.tar.gz" target="_blank">Source Code for 1.7.0 (TAR.GZ)</a> <i class="fa fa-download"></i></b><br />
-                                    Source code for Celestia 1.7.0 in a gzip archive.</li>
+                                	This version will run on any computer with either an x86 or x86-64 type CPU.</li>
                                 </ul>
 
 								<!-- Install links provided by Lev. -->

--- a/win_170.html
+++ b/win_170.html
@@ -61,17 +61,18 @@
 						<!-- Content -->
 							<section id="content">
 								<header class="minor">
-									<h3>Celestia 1.7.0 is a rolling release, meaning that it will update relativly frequently, so check back constantly for updates. Celestia 1.7.0 on Windows also comes in multiple versions that can be downloaded below.</h3>
+									<h3>Celestia 1.7.0 is a rolling release, meaning that it will update relatively frequently, so check back constantly for updates. Celestia 1.7.0 on Windows also comes in multiple versions that can be downloaded below.</h3>
 								</header>
 								
 								<ul>
-                                	<li><b><a href="https://github.com/celestiamobile/celestia-170/releases/download/latest/CelestiaInstaller-x64.exe" target="_blank">Celestia 1.7.0 for x64 based Windows Systems (345 MB)</a><i class="fa fa-download"></i></b><br />
+                                	<li><b><a href="https://github.com/celestiamobile/celestia-170/releases/download/latest/CelestiaInstaller-x64.exe" target="_blank">Celestia 1.7.0 for x64 based Windows Systems (345 MB)</a> <i class="fa fa-download"></i></b><br />
                                 	This version will run on any computer with an amd64 type CPU.<br /></li>
-                                	<li><b><a href="https://github.com/celestiamobile/celestia-170/releases/download/latest/CelestiaInstaller-x86.exe" target="_blank">Celestia 1.7.0 for x86 based Windows Systems (332 MB)</a><i class="fa fa-download"></i></b><br />
+                                	<li><b><a href="https://github.com/celestiamobile/celestia-170/releases/download/latest/CelestiaInstaller-x86.exe" target="_blank">Celestia 1.7.0 for x86 based Windows Systems (332 MB)</a> <i class="fa fa-download"></i></b><br />
                                 	This version will run on any computer with either an i686 or amd64 type CPU.</li>
-                                	<li><b><a href="https://github.com/celestiamobile/celestia-170/archive/refs/tags/latest.zip" target="_blank">Source Code for 1.7.0 (ZIP Archive)</a><i class="fa fa-download"></i></b></li><br />
-                                	<li><b><a href="https://github.com/celestiamobile/celestia-170/archive/refs/tags/latest.tar.gz" target="_blank">Source Code for 1.7.0 (TAR.GZ Archive)</a><i class="fa fa-download"></i></b><br />
-                                	If you want to compile Celestia from source, you can download the source code directly.<br /></li>
+                                	<li><b><a href="https://github.com/celestiamobile/celestia-170/archive/refs/tags/latest.zip" target="_blank">Source Code for 1.7.0 (ZIP)</a> <i class="fa fa-download"></i></b><br />
+                                    Source code for Celestia 1.7.0 in a ZIP archive.</li>
+                                	<li><b><a href="https://github.com/celestiamobile/celestia-170/archive/refs/tags/latest.tar.gz" target="_blank">Source Code for 1.7.0 (TAR.GZ)</a> <i class="fa fa-download"></i></b><br />
+                                    Source code for Celestia 1.7.0 in a gzip archive.</li>
                                 </ul>
 
 								<!-- Install links provided by Lev. -->


### PR DESCRIPTION
Adds an embed to the Steam page for Celestia. I will change this section of the page the day before the Steam release.
<img width="1153" height="476" alt="image" src="https://github.com/user-attachments/assets/5beaaec2-33f8-4d06-add8-d392caa80082" />

I've also added some information to the macOS downloads section, fixed some small grammatical errors, and just changed the wording of some stuff on the 1.7.0 download page.

Setting this as a draft for now.