### PR TITLE
Clean up download pages and CSS

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -3319,17 +3319,6 @@
 						display: none;
 					}
 
-		#eol-warning {
-			background: linear-gradient(#00000000, #ff0000 20%, #ff0000 80%, #00000000);
-			height: 3.5em;
-			left: 0;
-			line-height: 3.5em;
-			position: relative;
-			top: 3.5em;
-			width: 100%;
-			z-index: 100;
-		}
-
 	body.landing #page-wrapper {
 		padding-top: 0;
 	}

--- a/download.html
+++ b/download.html
@@ -66,7 +66,7 @@
 								<center>
 								<i class="fa fa-windows fa-5x"></i>
 								<h2>Windows</h2>
-                                <p>Celestia is now available to purchase on Steam! The price is 1.99 USD with a 40% discount for the first 14 days. Benefits include Steam Workshop integration, allowing for easy add-on management, and regular updates which add features and improvements. You'll also be directly supporting the project</p>
+                                <p>Celestia is available to purchase on Steam. Benefits include Steam Workshop integration, allowing for easy add-on management, and regular updates which add features and improvements. You'll also be directly supporting the project.</p>
                                 <iframe src="https://store.steampowered.com/widget/4753420/" frameborder="0" width="646" height="190"></iframe>
 								<p>If you wish to download Celestia directly to your computer instead, use one of the links below. The Windows package of Celestia is a self-extracting archive. Choose the version you want, download it to your computer and then run it.</p>
 								</center>
@@ -74,7 +74,7 @@
 									<div class="8u 12u$(xsmall)">
 										<center>
 											<ul class="actions fit">
-												<li><a href="win_170.html" target="_blank" class="button special">Celestia 1.7.0 (x86/x64)</a></li>
+												<li><a href="win_170.html" class="button special">Celestia 1.7.0 (x86/x64)</a></li>
 												<li><a href="https://github.com/CelestiaProject/Celestia/releases/download/1.6.4/celestia-1.6.4.exe" class="button special icon fa-download">Celestia 1.6.4 (x86/x64, 36M)</a></li>
 												<li><a href="https://github.com/CelestiaProject/Celestia/releases/download/1.6.3/celestia-1.6.3.exe" class="button icon fa-download">Celestia 1.6.3 (x86/x64, 36M)</a></li>
 											</ul>
@@ -84,7 +84,7 @@
 								<center>
 								<i class="fa fa-apple fa-5x"></i>
 								<h2>macOS</h2>
-								<p>Celestia 1.7.0 for macOS can be downloaded from the macOS App Store. The macOS packages for older versions, available below, are zipped bundles. Choose your version, then download it and unpack.</p>
+								<p>Celestia 1.7.0 for macOS can be downloaded from the Mac App Store. The macOS packages for older versions, available below, are zipped bundles. Choose your version, then download it and unpack.</p>
 								</center>
 								<div class="row">
 									<div class="6u 12u$(xsmall)">

--- a/win_170.html
+++ b/win_170.html
@@ -61,7 +61,7 @@
 						<!-- Content -->
 							<section id="content">
 								<header class="minor">
-									<h3>Celestia 1.7.0 is a rolling release, meaning that it will update relatively frequently, so check back constantly for updates. Celestia 1.7.0 on Windows also comes in multiple versions that can be downloaded below.</h3>
+									<h3>Celestia 1.7.0 is still under active development, meaning you may encounter bugs, performance issues, crashes, and incomplete features. This is a nightly build, so be sure to check back regularly for updates.</h3>
 								</header>
 
 								<ul>


### PR DESCRIPTION
This PR rewords some information on the download page, removes information pertaining to the Steam launch discount in particular, which is no longer in effect, and removes a bit of unused CSS.